### PR TITLE
Fix the if statement of Tile#renderCache()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 3.0.1
+* `Tile#renderCache()` 内の条件分岐箇所のバグを修正
+
 ## 3.0.0
 * akashic-engine@3.0.0 に追従
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/akashic-tile",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Tilemap library for Akashic Engine",
   "main": "lib/index.js",
   "scripts": {

--- a/spec/TileSpec.js
+++ b/spec/TileSpec.js
@@ -166,4 +166,31 @@ describe("Tile", function() {
 		expect(c).toBe(4);
 	});
 
+	it("render not use redrawArea", function () {
+		jasmine.addMatchers(require("./lib/customMatchers"));
+		var runtime = skeletonRuntime();
+		var surface = new mock.Surface(20, 10);
+		var tileData = [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]];
+
+		var tile = new Tile({
+			scene: runtime.scene,
+			src: surface,
+			tileWidth: 10,
+			tileHeight: 10,
+			tileData: tileData
+		});
+		tile._drawnTileData = [[-1, -1, -1, -1], [-1, -1, -1, -1], [-1, -1, -1, -1], [-1, -1, -1, -1]];
+
+		var r = new mock.Renderer();
+		tile.invalidate();
+		tile.renderCache(r);
+		var c = r.methodCallParamsHistory("drawImage").length;
+		expect(c).toBe(16);
+
+		tile.redrawArea = null;
+		tile.invalidate();
+		tile.renderCache(r);
+		var c = r.methodCallParamsHistory("drawImage").length;
+		expect(c).toBe(16);
+	});
 });

--- a/src/Tile.ts
+++ b/src/Tile.ts
@@ -137,7 +137,7 @@ export class Tile extends g.CacheableE {
 				var dx = this.tileWidth * x;
 				var dy = this.tileHeight * y;
 
-				if (this.redrawArea !== undefined) {
+				if (this.redrawArea) {
 					if (dx + this.tileWidth < this.redrawArea.x || dx >= this.redrawArea.x + this.redrawArea.width ||
 						dy + this.tileHeight < this.redrawArea.y || dy >= this.redrawArea.y + this.redrawArea.height) {
 						continue;


### PR DESCRIPTION
## 概要

`Tile#renderCache()` 内の条件分岐箇所のバグを修正します。
対象箇所の `this.redrawArea`の型が null がありえるため、`if (this.redrawArea) {...` へ修正。
